### PR TITLE
fix: use proper template id for verify

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -351,8 +351,8 @@ const FEEDBACK = {
 }
 
 const HDS_HOURS = {
-  start: [8,0],
-  end: [17,0]
+  start: [8, 0],
+  end: [17, 0]
 }
 
 const defaults = {
@@ -372,7 +372,7 @@ const defaults = {
   VERIFY: {
     SID: 'VA716caeea7edda3401dc5f4e9a2e4bc99',
     CHANNEL_CONFIGURATION: {
-      template_id: 'd-731f00a0bfbd472fa144d863869d145d',
+      template_id: 'complete-trip-verification-code',
       from: 'team@etchgis.com',
       from_name: 'Etch',
     },


### PR DESCRIPTION
This pull request includes a small update to the `src/config.js` file. The change updates the `template_id` value in the `CHANNEL_CONFIGURATION` object within the `VERIFY` configuration to use a more descriptive identifier (`complete-trip-verification-code`) instead of the previous UUID-style value.